### PR TITLE
Changed 'report-options' to 'report-config' in karma.conf.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ module.exports = function (config) {
       fixWebpackSourcePaths: true,
 
        // Most reporters accept additional config options. You can pass these through the `report-config` option
-      'report-options': {
+      'report-config': {
 
         // all options available at: https://github.com/istanbuljs/istanbul-reports/blob/590e6b0089f67b723a1fdf57bc7ccc080ff189d7/lib/html/index.js#L135-L137
         html: {


### PR DESCRIPTION
In the example of karma.conf.js in README.md, the property to hold reporter configuration must be 'report-config' instead of 'report-options', as stated in the comment above the corresponding line.