### PR TITLE
fix: all browsers should have their own output folder when not combined

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -60,12 +60,16 @@ function CoverageIstanbulReporter(baseReporterDecorator, logger, config) {
   }
 
   function createReport(browserOrBrowsers, results) {
-    if (!coverageConfig.combineBrowserReports && coverageConfig.dir) {
-      coverageConfig.dir = coverageConfig.dir.replace(BROWSER_PLACEHOLDER, browserOrBrowsers.name);
-    }
+    const reportConfigOverride = (!coverageConfig.combineBrowserReports && coverageConfig.dir) ?
+      {dir: coverageConfig.dir.replace(BROWSER_PLACEHOLDER, browserOrBrowsers.name)} :
+      {};
 
     const reportConfig = istanbul.config.loadObject({
-      reporting: coverageConfig
+      reporting: Object.assign(
+        {},
+        coverageConfig,
+        reportConfigOverride
+      )
     });
     const reportTypes = reportConfig.reporting.config.reports;
 


### PR DESCRIPTION
When using the `combineBrowserReports` feature to `false`, all browsers reports outputs to the same folder (which is named after the first browser) instead of the pre #35 behavior with each browser having his own output folder.

These changes fixes this problem by **not** overriding the configuration.

I'm open for suggestions to complete the tests. But since I don't know what are the restrictions set on the CI server, I can't add a launcher other than the PhantomJS already present.