### PR TITLE
fix: use indexOf to check coverage map

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -103,7 +103,7 @@ function CoverageIstanbulReporter(baseReporterDecorator, logger, config) {
 
     if (!coverageConfig.skipFilesWithNoCoverage) {
       coverageMap.files().forEach(path => {
-        if (!(path in remappedCoverageMap)) {
+        if (remappedCoverageMap.files().indexOf(path) === -1) {
           // Re-add empty coverage record
           remappedCoverageMap.addFileCoverage(path);
         }


### PR DESCRIPTION
The "in" operator only check if property exists.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in
```js
// Arrays
var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
0 in trees        // returns true
3 in trees        // returns true
6 in trees        // returns false
'bay' in trees    // returns false (you must specify the index number, not the value at that index)
'length' in trees // returns true (length is an Array property)
Symbol.iterator in trees // returns true (arrays are iterable, works only in ES2015+)
```
Current condition is always true.