### PR TITLE
Use same default logic as webpack for identifying the source root

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -102,8 +102,13 @@ function CoverageIstanbulReporter(baseReporterDecorator, logger, config) {
       .map;
 
     if (!coverageConfig.skipFilesWithNoCoverage) {
+      // On Windows, istanbul returns files with mixed forward/backslashes in them
+      const fixedFilePaths = {};
+      remappedCoverageMap.files().forEach(path => {
+        fixedFilePaths[util.fixPathSeparators(path)] = true;
+      });
       coverageMap.files().forEach(path => {
-        if (!(path in remappedCoverageMap)) {
+        if (!(util.fixPathSeparators(path) in fixedFilePaths)) {
           // Re-add empty coverage record
           remappedCoverageMap.addFileCoverage(path);
         }

--- a/src/util.js
+++ b/src/util.js
@@ -90,6 +90,7 @@ function overrideThresholds(key, overrides, basePath) {
   return thresholds;
 }
 
+module.exports.fixPathSeparators = fixPathSeparators;
 module.exports.fixWebpackSourcePaths = fixWebpackSourcePaths;
 module.exports.fixWebpackFilePath = fixWebpackFilePath;
 module.exports.overrideThresholds = overrideThresholds;

--- a/src/util.js
+++ b/src/util.js
@@ -24,16 +24,18 @@ function fixPathSeparators(filePath) {
 
 function fixWebpackSourcePaths(sourceMap, webpackConfig) {
   let { sourceRoot } = sourceMap;
+  // As per https://webpack.js.org/configuration/entry-context/#context, if no context is specified, the current
+  // directory that the process is running from should be assumed instead
+  const context = (webpackConfig && webpackConfig.context) || process.cwd();
   // Fix for https://github.com/mattlewis92/karma-coverage-istanbul-reporter/issues/32
   // The sourceRoot is relative to the project directory and not an absolute path, so add the webpack context to it if set
   if (
-    webpackConfig &&
-    webpackConfig.context &&
-    sourceMap.sourceRoot &&
-    !sourceMap.sourceRoot.startsWith(webpackConfig.context) &&
+    context &&
+    sourceRoot &&
+    !sourceRoot.startsWith(context) &&
     !path.isAbsolute(sourceRoot)
   ) {
-    sourceRoot = path.join(webpackConfig.context, sourceRoot);
+    sourceRoot = path.join(context, sourceRoot);
   }
 
   sourceRoot = fixPathSeparators(sourceRoot);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -24,7 +24,7 @@ const webpackConfig = {
         exclude: /node_modules/
       },
       {
-        test: /src\/.+\.ts$/,
+        test: /\.ts$/,
         exclude: /(node_modules|\.spec\.ts$)/,
         loader: 'istanbul-instrumenter-loader',
         enforce: 'post',

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -59,6 +59,7 @@ describe('util', () => {
       Object.defineProperty(process, 'platform', {
         value: 'win32'
       });
+      process.cwd = () => 'C:/development/git/coverage-istanbul-reporter-path';
       const input = {
         file:
           'C:/development/git/coverage-istanbul-reporter-path/client/modules/app/app.component.ts',
@@ -118,6 +119,7 @@ describe('util', () => {
     });
 
     it('should remove the sourceRoot from the source path if present', () => {
+      process.cwd = () => 'C:/development/git/coverage-istanbul-reporter-path';
       const input = {
         file:
           'C:/development/git/coverage-istanbul-reporter-path/client/modules/app/app.component.ts',
@@ -175,6 +177,29 @@ describe('util', () => {
       ).to.deep.equal(output);
     });
 
+    it('should use the current directory if webpack context is not set', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32'
+      });
+      process.cwd = () =>
+        'C:\\Users\\mattlewis\\Code\\open-source\\karma-coverage-istanbul-reporter\\test\\fixtures\\typescript';
+      const input = {
+        file: 'example.ts',
+        sourceRoot: 'src/',
+        sources: [
+          'C:\\Users\\mattlewis\\Code\\open-source\\karma-coverage-istanbul-reporter\\test\\fixtures\\typescript\\src\\example.ts'
+        ]
+      };
+
+      const output = {
+        file: 'example.ts',
+        sourceRoot:
+          'C:\\Users\\mattlewis\\Code\\open-source\\karma-coverage-istanbul-reporter\\test\\fixtures\\typescript\\src\\',
+        sources: ['example.ts']
+      };
+      expect(fixWebpackSourcePaths(input, undefined)).to.deep.equal(output);
+    });
+
     it('should only add the webpack context to the source root if not already set', () => {
       const input = {
         file: 'example.ts',
@@ -197,7 +222,7 @@ describe('util', () => {
       ).to.deep.equal(output);
     });
 
-    it('should not the webpack context to the source root if the source root is absolute', () => {
+    it('should not add the webpack context to the source root if the source root is absolute', () => {
       const input = {
         file: 'example.ts',
         sourceRoot:


### PR DESCRIPTION
Based on https://webpack.js.org/configuration/entry-context/#context, if the context is not specified, the current directory that the process is running from should be assumed instead.

Align util to mimic this behaviour to ensure paths are correctly de-absoluted during processing.

This addresses an issue reported in https://github.com/aurelia/cli/issues/996#issuecomment-446069267