### PR TITLE
added check for ignoreSourceMap option

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -99,8 +99,10 @@ function CoverageIstanbulReporter(baseReporterDecorator, logger, config) {
       addCoverage(coverageMap, browserOrBrowsers);
     }
 
-    const remappedCoverageMap = sourceMapStore.transformCoverage(coverageMap)
-      .map;
+    let remappedCoverageMap = coverageMap;
+    if (!coverageConfig.ignoreSourceMap) {
+      remappedCoverageMap = sourceMapStore.transformCoverage(coverageMap).map;
+    }
 
     if (!coverageConfig.skipFilesWithNoCoverage) {
       // On Windows, istanbul returns files with mixed forward/backslashes in them


### PR DESCRIPTION
Hi Matt.  I am using the Karma Istanbul Reporter for an Angular 6 project with multiple custom projects/libraries.  The projects import modules from each other, which come from the dist folder of the library.  When  run on a given project, the reporter would give the stats on the files in the dist folders of the libraries that are dependencies of the project being tested.  The reporter was using the source-maps in these libraries to try to break down the tests to their sources, but it was generating paths that included "ng:", which resulted in an error on my Windows machine, since "ng:" is an invalid directory name.  I do not really care about these source mappings for my purposes, and because it was causing this error, I created an option to ignore the source mappings.  

I know the code I am submitting for this review may need further work, etc., but I figured this was the best way of reaching you with this feature request.  Let me know what you think / next steps, or if there was  some other way to do what I wanted.

I am attaching an image of one of my index files for one of the projects.  See how when the reporter would attempt to write an index.html file for the first folder listed, the "ng:" in the path would cause the reporter to fail.

![part of coverage result](https://user-images.githubusercontent.com/10551665/53521124-f61e4980-3a9c-11e9-9841-ee98dd0790c2.PNG)
