### PR TITLE
feat: add temporary istambul report file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ module.exports = function(config) {
       // base output directory. If you include %browser% in the path it will be replaced with the karma browser name
       dir: path.join(__dirname, 'coverage'),
 
+      // temporary output directory. Directory to output raw coverage information to
+      tempDirectory: path.join(__dirname, '.nyc_output'),
+
       // Combines coverage information from multiple browsers into one report rather than outputting a report
       // for each browser.
       combineBrowserReports: true,
@@ -97,24 +100,24 @@ module.exports = function(config) {
 
 ### List of reporters and options
 
-* [clover](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/clover/index.js#L8-L9)
-* [cobertura](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/cobertura/index.js#L9-L10)
-* [html](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/html/index.js#L135-L137)
-* [json-summary](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/json-summary/index.js#L8)
-* [json](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/json/index.js#L8)
-* lcov
-* [lcovonly](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/lcovonly/index.js#L8)
-* none
-* [teamcity](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/teamcity/index.js#L9-L10)
-* [text-lcov](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text-lcov/index.js#L9)
-* [text-summary](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text-summary/index.js#L9)
-* [text](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text/index.js#L159-L160)
+- [clover](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/clover/index.js#L8-L9)
+- [cobertura](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/cobertura/index.js#L9-L10)
+- [html](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/html/index.js#L135-L137)
+- [json-summary](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/json-summary/index.js#L8)
+- [json](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/json/index.js#L8)
+- lcov
+- [lcovonly](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/lcovonly/index.js#L8)
+- none
+- [teamcity](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/teamcity/index.js#L9-L10)
+- [text-lcov](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text-lcov/index.js#L9)
+- [text-summary](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text-summary/index.js#L9)
+- [text](https://github.com/istanbuljs/istanbuljs/blob/aae256fb8b9a3d19414dcf069c592e88712c32c6/packages/istanbul-reports/lib/text/index.js#L159-L160)
 
 ## Credits
 
-* [Original karma-coverage source](https://github.com/karma-runner/karma-coverage/blob/master/lib/reporter.js)
-* [Example of using the new reporter API](https://github.com/facebook/jest/blob/master/scripts/mapCoverage.js)
-* [Karma remap istanbul](https://github.com/marcules/karma-remap-istanbul)
+- [Original karma-coverage source](https://github.com/karma-runner/karma-coverage/blob/master/lib/reporter.js)
+- [Example of using the new reporter API](https://github.com/facebook/jest/blob/master/scripts/mapCoverage.js)
+- [Karma remap istanbul](https://github.com/marcules/karma-remap-istanbul)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,6 +2069,12 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-spies": {
+      "version": "1.0.0",
+      "resolved": "http://sinopia.verstehe.local:4873/chai-spies/-/chai-spies-1.0.0.tgz",
+      "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+      "dev": true
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5615,14 +5615,13 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "http://sinopia.verstehe.local:4873/fs-extra/-/fs-extra-8.0.1.tgz",
+      "integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -6625,8 +6624,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
       "version": "1.10.5",
@@ -8032,10 +8030,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "http://sinopia.verstehe.local:4873/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -10521,6 +10518,28 @@
         "request": "^2.81.0",
         "request-progress": "^2.0.1",
         "which": "^1.2.10"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "1.0.0",
+          "resolved": "http://sinopia.verstehe.local:4873/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://sinopia.verstehe.local:4873/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "pify": {
@@ -13421,8 +13440,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/mattlewis92/karma-coverage-istanbul-reporter#readme",
   "dependencies": {
+    "fs-extra": "^8.0.1",
     "istanbul-api": "^2.1.1",
     "minimatch": "^3.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
     "chai": "^4.2.0",
+    "chai-spies": "^1.0.0",
     "codecov-lite": "^0.1.3",
     "commitizen": "^3.0.5",
     "husky": "^1.3.1",

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -78,6 +78,29 @@ describe('karma-coverage-istanbul-reporter', () => {
     });
   });
 
+  it('should generate a temporary istanbul coverage file', done => {
+    const tempDirectory = path.join(__dirname, 'fixtures', '.nyc_output');
+    const server = createServer({
+      coverageIstanbulReporter: {
+        tempDirectory,
+        dir: path.join(__dirname, 'fixtures', 'outputs')
+      }
+    });
+    server.start();
+    server.on('run_complete', () => {
+      setTimeout(() => {
+        // Hacky workaround to make sure the file has been written
+        const tempDirFiles = fs.readdirSync(tempDirectory);
+        const temporaryCoverageReport = JSON.parse(
+          fs.readFileSync(path.join(tempDirectory, tempDirFiles[0]))
+        );
+        expect(tempDirFiles).length(1);
+        expect(temporaryCoverageReport).to.be.a('object');
+        done();
+      }, fileReadTimeout);
+    });
+  });
+
   it('should fix webpack loader source paths', done => {
     const server = createServer({
       coverageIstanbulReporter: {

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -1,7 +1,8 @@
 /* eslint-disable max-nested-callbacks */
-const fs = require('fs');
 const path = require('path');
 const chai = require('chai');
+const fs = require('fs-extra');
+const spies = require('chai-spies');
 const karma = require('karma');
 const rimraf = require('rimraf');
 const karmaCoverageIstanbulReporter = require('../src/reporter');
@@ -12,6 +13,8 @@ const OUTPUT_PATH = path.join(__dirname, 'fixtures', 'outputs');
 const OUTPUT_FILE = path.join(OUTPUT_PATH, 'coverage-summary.json');
 const OUTPUT_DETAILS_FILE = path.join(OUTPUT_PATH, 'coverage-final.json');
 const fileReadTimeout = 300;
+
+chai.use(spies);
 
 function createServer(config) {
   config = config || {};
@@ -80,6 +83,7 @@ describe('karma-coverage-istanbul-reporter', () => {
 
   it('should generate a temporary istanbul coverage file', done => {
     const tempDirectory = path.join(__dirname, 'fixtures', '.nyc_output');
+    chai.spy.on(fs, ['writeFileSync']);
     const server = createServer({
       coverageIstanbulReporter: {
         tempDirectory,
@@ -96,6 +100,36 @@ describe('karma-coverage-istanbul-reporter', () => {
         );
         expect(tempDirFiles).length(1);
         expect(temporaryCoverageReport).to.be.a('object');
+        expect(fs.writeFileSync).to.have.been.called();
+        chai.spy.restore(fs, ['writeFileSync']);
+        done();
+      }, fileReadTimeout);
+    });
+  });
+
+  it('should recreate the temp directory', done => {
+    const tempDirectory = path.join(__dirname, 'fixtures', '.nyc_output');
+    fs.removeSync(tempDirectory);
+    fs.mkdirSync(tempDirectory);
+
+    chai.spy.on(fs, ['existsSync', 'removeSync', 'mkdirSync']);
+
+    const server = createServer({
+      coverageIstanbulReporter: {
+        tempDirectory,
+        dir: path.join(__dirname, 'fixtures', 'outputs')
+      }
+    });
+    server.start();
+    server.on('run_complete', () => {
+      setTimeout(() => {
+        // Hacky workaround to make sure the file has been written
+        expect(fs.existsSync).to.have.be.called.with(tempDirectory);
+        expect(fs.removeSync).to.have.be.called.with(tempDirectory);
+        expect(fs.mkdirSync).to.have.be.called.with(tempDirectory, {
+          recursive: true
+        });
+        chai.spy.restore(fs, ['existsSync', 'removeSync', 'mkdirSync']);
         done();
       }, fileReadTimeout);
     });


### PR DESCRIPTION
I add the ability to generate a temporary coverage report file like nyc did it. 
On this way we are able to merge multiple test coverage reports into a single report file.
For example, if you use a monorepository with multiple project and each of these projects should generate his own once but these report should be summed up in one report.