### PR TITLE
Add option to exclude files from coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ module.exports = function(config) {
         }
       },
 
-      verbose: true // output config used by istanbul for debugging
+      verbose: true, // output config used by istanbul for debugging
+
+      // Glob patterns to exclude from coverage reporting
+      exclude: [
+        '**/test/**',
+      ],
     }
   });
 };

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -4,6 +4,7 @@ const libSourceMaps = require('istanbul-lib-source-maps');
 const libReport = require('istanbul-lib-report');
 const libReports = require('istanbul-reports');
 const util = require('./util');
+const minimatch = require('minimatch');
 
 const BROWSER_PLACEHOLDER = '%browser%';
 
@@ -45,6 +46,13 @@ function CoverageIstanbulReporter(baseReporterDecorator, logger, config) {
     }
 
     Object.keys(coverage).forEach((filename) => {
+      if (
+        coverageConfig.exclude &&
+        coverageConfig.exclude.some((exclude) => minimatch(filename, exclude))
+      ) {
+        return;
+      }
+
       const fileCoverage = coverage[filename];
       if (fileCoverage.inputSourceMap && coverageConfig.fixWebpackSourcePaths) {
         fileCoverage.inputSourceMap = util.fixWebpackSourcePaths(

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -558,4 +558,27 @@ describe('karma-coverage-istanbul-reporter', () => {
       server.start();
     });
   });
+
+  describe('exclusions', () => {
+    it('excludes files', (done) => {
+      const server = createServer({
+        coverageIstanbulReporter: {
+          exclude: ['**/another-file.ts'],
+        },
+      });
+
+      server.start();
+
+      server.on('run_complete', () => {
+        setTimeout(() => {
+          const summary = JSON.parse(fs.readFileSync(OUTPUT_FILE));
+          for (const key of Object.keys(summary)) {
+            expect(key).not.to.contain('another-file');
+          }
+
+          done();
+        }, fileReadTimeout);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This change adds an option to exclude files from coverage via globs.

This behaviour used to be achievable in v2 using the `instrumentation`
option, but this no longer works in v3.

This is configured in the `coverageIstanbulReporter` options:

```javascript
coverageIstanbulReporter: {
  exclude: [
    '**/path/to/exclude/**/*.js',
  ],
}
```